### PR TITLE
Bandarussr/2fa signin page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-slot": "^1.0.2",
     "@tanstack/react-table": "^8.10.7",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@emotion/styled':
     specifier: ^11.11.0
     version: 11.11.0(@emotion/react@11.11.1)(@types/react@18.2.21)(react@18.2.0)
+  '@radix-ui/react-label':
+    specifier: ^2.0.2
+    version: 2.0.2(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-slot':
     specifier: ^1.0.2
     version: 1.0.2(@types/react@18.2.21)(react@18.2.0)
@@ -1012,6 +1015,48 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-label@2.0.2(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-N5ehvlM7qoTLx7nWPodsPYPgMzA5WM8zZChQg8nyFJKnDO5WHdba1vv5/H6IO5LtJMfD2Q3wh1qHFGNtK0w3bQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.11
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.21
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-primitive@1.0.3(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.11
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.21)(react@18.2.0)
+      '@types/react': 18.2.21
+      '@types/react-dom': 18.2.7
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-slot@1.0.2(@types/react@18.2.21)(react@18.2.0):
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
     peerDependencies:
@@ -1225,7 +1270,6 @@ packages:
     resolution: {integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==}
     dependencies:
       '@types/react': 18.2.21
-    dev: true
 
   /@types/react@18.2.21:
     resolution: {integrity: sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==}

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link';
+import SignInForm from '@/components/SignInForm';
+
+export default function AuthenticationPage() {
+  return (
+    <>
+      <div className="container relative h-screen flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
+        <div className="relative hidden h-full flex-col bg-muted p-10 text-white dark:border-r lg:flex">
+          <div className="absolute inset-0 bg-sky-800" />
+          <div className="relative z-20 flex items-center text-lg font-medium">
+            {/* Replace SVG with UW211 logo here... */}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="mr-2 h-6 w-6"
+            >
+              <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
+            </svg>
+            United Way 211
+          </div>
+          <div className="relative z-20 mt-auto">
+            <blockquote className="space-y-2">
+              <p className="text-lg">
+                &ldquo;United Way of Greater Knoxville is driving change in our
+                community by uniting people, businesses, and organizations.
+                Together, we&apos;re creating a more equitable Knoxville where
+                we have stable housing, financial security, quality early care
+                and education, access to food, and more.{' '}
+                <b>Join us and answer the call.</b>&rdquo;
+              </p>
+            </blockquote>
+          </div>
+        </div>
+        <div className="p-8">
+          <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
+            <div className="flex flex-col space-y-2 text-center">
+              <h1 className="text-2xl font-semibold tracking-tight">Sign in</h1>
+            </div>
+            <SignInForm />
+            <p className="px-8 text-center text-sm text-muted-foreground">
+              By clicking continue, you agree to our{' '}
+              <Link
+                href="/terms"
+                className="underline underline-offset-4 hover:text-primary"
+              >
+                Terms of Service
+              </Link>{' '}
+              and{' '}
+              <Link
+                href="/privacy"
+                className="underline underline-offset-4 hover:text-primary"
+              >
+                Privacy Policy
+              </Link>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,14 +1,14 @@
 import Link from 'next/link';
 import SignInForm from '@/components/SignInForm';
 
-export default function AuthenticationPage() {
+export default function SignIn() {
   return (
     <>
       <div className="container relative h-screen flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
+        {/* Left side of signin page. Only visible on >=lg responsive breakpoints. */}
         <div className="relative hidden h-full flex-col bg-muted p-10 text-white dark:border-r lg:flex">
           <div className="absolute inset-0 bg-sky-800" />
           <div className="relative z-20 flex items-center text-lg font-medium">
-            {/* Replace SVG with UW211 logo here... */}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
@@ -36,6 +36,7 @@ export default function AuthenticationPage() {
             </blockquote>
           </div>
         </div>
+        {/* Right half of signin page. Visible at all times and contains signin form. */}
         <div className="p-8">
           <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
             <div className="flex flex-col space-y-2 text-center">

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -8,7 +8,10 @@ export default function SignIn() {
         {/* Left side of signin page. Only visible on >=lg responsive breakpoints. */}
         <div className="relative hidden h-full flex-col bg-muted p-10 text-white dark:border-r lg:flex">
           <div className="absolute inset-0 bg-sky-800" />
-          <div className="relative z-20 flex items-center text-lg font-medium">
+          <Link
+            href="/"
+            className="relative z-20 flex items-center text-lg font-medium"
+          >
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
@@ -21,8 +24,8 @@ export default function SignIn() {
             >
               <path d="M15 6v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3V6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3" />
             </svg>
-            United Way 211
-          </div>
+            United Way Knoxville 211
+          </Link>
           <div className="relative z-20 mt-auto">
             <blockquote className="space-y-2">
               <p className="text-lg">

--- a/src/components/SignInForm/index.tsx
+++ b/src/components/SignInForm/index.tsx
@@ -1,26 +1,31 @@
 'use client';
 
-import { SyntheticEvent, useState } from 'react';
+import { HTMLAttributes, SyntheticEvent, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
-interface SignInFormProps extends React.HTMLAttributes<HTMLDivElement> {}
-interface IconProps extends React.HTMLAttributes<SVGElement> {}
+interface SignInFormProps extends HTMLAttributes<HTMLDivElement> {}
+interface IconProps extends HTMLAttributes<SVGElement> {}
 
 const Icons = {
   microsoft: (props: IconProps) => (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      height="24px"
-      width="24px"
-      {...props}
-    >
+    <svg viewBox="0 0 24 24" {...props}>
       <path
-        d="M0 0h2311v2310H0zm2564 0h2311v2310H2564zM0 2564h2311v2311H0zm2564 0h2311v2311H2564"
-        fill="currentColor"
-        width="24"
-      />
+        d="M 0 0 L 11.377 0 L 11.377 11.372 L 0 11.372 L 0 0 Z"
+        transform="matrix(1, 0, 0, 1, 0, 8.881784197001252e-16)"
+      ></path>
+      <path
+        d="M 12.623 12.623 L 24 12.623 L 24 24 L 12.623 24"
+        transform="matrix(1, 0, 0, 1, 0, 8.881784197001252e-16)"
+      ></path>
+      <path
+        d="M 0 12.623 L 11.377 12.623 L 11.377 24 L 0 24 L 0 12.623 Z"
+        transform="matrix(1, 0, 0, 1, 0, 8.881784197001252e-16)"
+      ></path>
+      <path
+        d="M 12.623 0 L 24 0 L 24 11.372 L 12.623 11.372 L 12.623 0 Z"
+        transform="matrix(1, 0, 0, 1, 0, 8.881784197001252e-16)"
+      ></path>
     </svg>
   ),
   spinner: (props: IconProps) => (

--- a/src/components/SignInForm/index.tsx
+++ b/src/components/SignInForm/index.tsx
@@ -3,6 +3,7 @@
 import { HTMLAttributes, SyntheticEvent, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { useRouter } from 'next/navigation';
 
 interface SignInFormProps extends HTMLAttributes<HTMLDivElement> {}
 interface IconProps extends HTMLAttributes<SVGElement> {}
@@ -48,10 +49,19 @@ const Icons = {
 
 export default function SignInForm({ className, ...props }: SignInFormProps) {
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const router = useRouter();
 
   async function onClick(event: SyntheticEvent) {
     event.preventDefault();
     setIsLoading(true);
+
+    // Implement authentication here...
+    const auth = true; // isAuthenticated();
+    if (auth) {
+      setIsLoading(false);
+      router.push('/dashboard');
+    }
+    // else, redirect to 2FA
 
     setTimeout(() => {
       setIsLoading(false);

--- a/src/components/SignInForm/index.tsx
+++ b/src/components/SignInForm/index.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { SyntheticEvent, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface SignInFormProps extends React.HTMLAttributes<HTMLDivElement> {}
+interface IconProps extends React.HTMLAttributes<SVGElement> {}
+
+const Icons = {
+  microsoft: (props: IconProps) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      height="24px"
+      width="24px"
+      {...props}
+    >
+      <path
+        d="M0 0h2311v2310H0zm2564 0h2311v2310H2564zM0 2564h2311v2311H0zm2564 0h2311v2311H2564"
+        fill="currentColor"
+        width="24"
+      />
+    </svg>
+  ),
+  spinner: (props: IconProps) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  ),
+};
+
+export default function SignInForm({ className, ...props }: SignInFormProps) {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  async function onClick(event: SyntheticEvent) {
+    event.preventDefault();
+    setIsLoading(true);
+
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 3000);
+  }
+
+  return (
+    <div className={cn('grid gap-6', className)} {...props}>
+      <Button variant="outline" onClick={onClick} disabled={isLoading}>
+        {isLoading ? (
+          <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <Icons.microsoft className="mr-2 h-4 w-4" />
+        )}{' '}
+        Microsoft SSO
+      </Button>
+    </div>
+  );
+}

--- a/src/components/SignInForm/index.tsx
+++ b/src/components/SignInForm/index.tsx
@@ -61,7 +61,7 @@ export default function SignInForm({ className, ...props }: SignInFormProps) {
         ) : (
           <Icons.microsoft className="mr-2 h-4 w-4" />
         )}{' '}
-        Microsoft SSO
+        Sign in with Microsoft
       </Button>
     </div>
   );

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const labelVariants = cva(
+  'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };


### PR DESCRIPTION
# Description
Created a `SignInForm` component with a signin button for Microsoft. Made a signin page using shadcn/ui's example authentication page as the template. Sign in button redirects to admin dashboard page. Example logo and "United Way Knoxville 211" text on the sign in page redirects to homepage.

## Relevant issue(s)
- #34 

## ~~Questions~~ Notes
- The Microsoft logo svg on some screens may appear blurry. I think it happens just because its so tiny...
- The example auth page had a spinner on it when clicked, I kept this there, we can probably use it while waiting for user to complete Microsoft auth.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR

# Testing
- To test the sign in page go to `/signin`. 
- To test loading spinner, change the `auth` value in the `onClick` to `false`.