### PR TITLE
Rudrapatel2003/single agency endpoint 41

### DIFF
--- a/src/app/api/agencies/[id]/route.ts
+++ b/src/app/api/agencies/[id]/route.ts
@@ -19,16 +19,14 @@ export async function GET(
     );
   } catch (error) {
     if (error instanceof JSendResponse) {
-      if (error instanceof JSendResponse) {
-        return Response.json(error, { status: 400 });
-      }
-      return Response.json(
-        new JSendResponse({
-          status: 'error',
-          message: 'Internal Server Error',
-        }),
-        { status: 500 }
-      );
+      return Response.json(error, { status: 400 });
     }
+    return Response.json(
+      new JSendResponse({
+        status: 'error',
+        message: 'Internal Server Error',
+      }),
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/agencies/[id]/route.ts
+++ b/src/app/api/agencies/[id]/route.ts
@@ -1,0 +1,34 @@
+import { getAgencyById } from '@/server/actions/Agencies';
+import { JSendResponse } from '@/utils/types';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  const id = params.id;
+
+  try {
+    const agency = await getAgencyById(id);
+
+    return Response.json(
+      new JSendResponse({
+        status: 'success',
+        data: { agency: agency },
+      }),
+      { status: 200 }
+    );
+  } catch (error) {
+    if (error instanceof JSendResponse) {
+      if (error instanceof JSendResponse) {
+        return Response.json(error, { status: 400 });
+      }
+      return Response.json(
+        new JSendResponse({
+          status: 'error',
+          message: 'Internal Server Error',
+        }),
+        { status: 500 }
+      );
+    }
+  }
+}

--- a/src/server/actions/Agencies.ts
+++ b/src/server/actions/Agencies.ts
@@ -96,6 +96,10 @@ export async function getAgencyById(id: string): Promise<Agency> {
     }
     return agency;
   } catch (error) {
+    // rethrow custom error to be handled by calling function
+    if (error instanceof JSendResponse) {
+      throw error;
+    }
     mongoErrorHandler(error as MongoError);
   }
   return {} as Agency;


### PR DESCRIPTION
# Description

Adds an endpoint that returns the agency corresponding with an Id. Returns a 400 error if not, with the error message either being the custom message indicating the agency is not found, a mongoose error, or, as a last resort, a default server error.

## Relevant issue(s)

- #41 

## Questions

- Where do we put documentation changes?

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
