### PR TITLE
Add mongodb-memory-server testing

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -11,7 +11,7 @@ const config = {
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 
-  testEnvironment: 'jest-environment-jsdom',
+  testEnvironment: 'node',
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clsx": "^2.0.0",
     "framer-motion": "^10.16.4",
     "lucide-react": "^0.286.0",
+    "mongodb-memory-server": "^9.1.1",
     "mongoose": "^7.4.5",
     "next": "13.4.19",
     "next-auth": "^4.24.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ dependencies:
   lucide-react:
     specifier: ^0.286.0
     version: 0.286.0(react@18.2.0)
+  mongodb-memory-server:
+    specifier: ^9.1.1
+    version: 9.1.1
   mongoose:
     specifier: ^7.4.5
     version: 7.4.5
@@ -917,6 +920,14 @@ packages:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
 
+  /@mongodb-js/saslprep@1.1.1:
+    resolution: {integrity: sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==}
+    requiresBuild: true
+    dependencies:
+      sparse-bitfield: 3.0.3
+    dev: false
+    optional: true
+
   /@next/env@13.4.19:
     resolution: {integrity: sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ==}
     dev: false
@@ -1757,6 +1768,15 @@ packages:
       - supports-color
     dev: true
 
+  /agent-base@7.1.0:
+    resolution: {integrity: sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==}
+    engines: {node: '>= 14'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -1935,6 +1955,12 @@ packages:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
     dev: true
 
+  /async-mutex@0.4.0:
+    resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
+
   /asynciterator.prototype@1.0.0:
     resolution: {integrity: sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==}
     dependencies:
@@ -1976,6 +2002,10 @@ packages:
     dependencies:
       dequal: 2.0.3
     dev: true
+
+  /b4a@1.6.4:
+    resolution: {integrity: sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==}
+    dev: false
 
   /babel-jest@29.6.4(@babel/core@7.22.11):
     resolution: {integrity: sha512-meLj23UlSLddj6PC+YTOFRgDAtjnZom8w/ACsrx0gtPtv5cJZk0A5Unk5bV4wixD7XaPCN1fQvpww8czkZURmw==}
@@ -2110,6 +2140,15 @@ packages:
     engines: {node: '>=14.20.1'}
     dev: false
 
+  /bson@5.5.1:
+    resolution: {integrity: sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==}
+    engines: {node: '>=14.20.1'}
+    dev: false
+
+  /buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+    dev: false
+
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
     dev: true
@@ -2151,7 +2190,6 @@ packages:
   /camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-    dev: true
 
   /caniuse-lite@1.0.30001523:
     resolution: {integrity: sha512-I5q5cisATTPZ1mc588Z//pj/Ox80ERYDfR71YnvY7raS/NOk8xXlZcB0sF7JdqaV//kOaa6aus7lRfpdnt1eBA==}
@@ -2303,6 +2341,10 @@ packages:
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  /commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
+    dev: false
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -3076,6 +3118,10 @@ packages:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
     dev: true
 
+  /fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+    dev: false
+
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
@@ -3105,6 +3151,12 @@ packages:
       bser: 2.1.1
     dev: true
 
+  /fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+    dependencies:
+      pend: 1.2.0
+    dev: false
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -3118,6 +3170,15 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
 
+  /find-cache-dir@3.3.2:
+    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
+    engines: {node: '>=8'}
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 3.1.0
+      pkg-dir: 4.2.0
+    dev: false
+
   /find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
     dev: false
@@ -3128,7 +3189,6 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    dev: true
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -3149,6 +3209,18 @@ packages:
   /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: true
+
+  /follow-redirects@1.15.3(debug@4.3.4):
+    resolution: {integrity: sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+    dev: false
 
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -3431,6 +3503,16 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /https-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==}
+    engines: {node: '>= 14'}
+    dependencies:
+      agent-base: 7.1.0
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -4435,7 +4517,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
-    dev: true
 
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -4492,6 +4573,13 @@ packages:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
     dev: true
+
+  /make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+    dependencies:
+      semver: 6.3.1
+    dev: false
 
   /make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -4570,6 +4658,47 @@ packages:
       whatwg-url: 11.0.0
     dev: false
 
+  /mongodb-memory-server-core@9.1.1:
+    resolution: {integrity: sha512-5toYR4A7DfV5k+Qf6L9FG86baID2rPP/JYwp8TPrdm8ZzfTfyHTwQwa2BzVpSwmLoVW5gXN0znYmXiE68mImMg==}
+    engines: {node: '>=14.20.1'}
+    dependencies:
+      async-mutex: 0.4.0
+      camelcase: 6.3.0
+      debug: 4.3.4
+      find-cache-dir: 3.3.2
+      follow-redirects: 1.15.3(debug@4.3.4)
+      https-proxy-agent: 7.0.2
+      mongodb: 5.9.1
+      new-find-package-json: 2.0.0
+      semver: 7.5.4
+      tar-stream: 3.1.6
+      tslib: 2.6.2
+      yauzl: 2.10.0
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - supports-color
+    dev: false
+
+  /mongodb-memory-server@9.1.1:
+    resolution: {integrity: sha512-ZOHOdb7//sBR2ea1lPHDPRaw8oO2MIfMdF+z82/KnzfNZ6yY6igR48cfG8u+QArKJQFsA392GMMHSevfPWsrRA==}
+    engines: {node: '>=14.20.1'}
+    requiresBuild: true
+    dependencies:
+      mongodb-memory-server-core: 9.1.1
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - supports-color
+    dev: false
+
   /mongodb@5.7.0:
     resolution: {integrity: sha512-zm82Bq33QbqtxDf58fLWBwTjARK3NSvKYjyz997KSy6hpat0prjeX/kxjbPVyZY60XYPDNETaHkHJI2UCzSLuw==}
     engines: {node: '>=14.20.1'}
@@ -4596,6 +4725,34 @@ packages:
       socks: 2.7.1
     optionalDependencies:
       saslprep: 1.0.3
+    dev: false
+
+  /mongodb@5.9.1:
+    resolution: {integrity: sha512-NBGA8AfJxGPeB12F73xXwozt8ZpeIPmCUeWRwl9xejozTXFes/3zaep9zhzs1B/nKKsw4P3I4iPfXl3K7s6g+Q==}
+    engines: {node: '>=14.20.1'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.188.0
+      '@mongodb-js/zstd': ^1.0.0
+      kerberos: ^1.0.0 || ^2.0.0
+      mongodb-client-encryption: '>=2.3.0 <3'
+      snappy: ^7.2.2
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+    dependencies:
+      bson: 5.5.1
+      mongodb-connection-string-url: 2.6.0
+      socks: 2.7.1
+    optionalDependencies:
+      '@mongodb-js/saslprep': 1.1.1
     dev: false
 
   /mongoose@7.4.5:
@@ -4653,6 +4810,15 @@ packages:
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
+
+  /new-find-package-json@2.0.0:
+    resolution: {integrity: sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      debug: 4.3.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /next-auth@4.24.5(next@13.4.19)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-3RafV3XbfIKk6rF6GlLE4/KxjTcuMCifqrmD+98ejFq73SRoj2rmzoca8u764977lH/Q7jo6Xu6yM+Re1Mz/Og==}
@@ -4900,7 +5066,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-try: 2.2.0
-    dev: true
 
   /p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -4914,7 +5079,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
-    dev: true
 
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -4926,7 +5090,6 @@ packages:
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -4952,7 +5115,6 @@ packages:
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -4974,6 +5136,10 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  /pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+    dev: false
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -5001,7 +5167,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
-    dev: true
 
   /postcss-import@15.1.0(postcss@8.4.31):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -5217,6 +5382,10 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  /queue-tick@1.0.1:
+    resolution: {integrity: sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==}
+    dev: false
 
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -5487,7 +5656,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5597,6 +5765,13 @@ packages:
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+    dev: false
+
+  /streamx@2.15.5:
+    resolution: {integrity: sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==}
+    dependencies:
+      fast-fifo: 1.3.2
+      queue-tick: 1.0.1
     dev: false
 
   /string-argv@0.3.2:
@@ -5831,6 +6006,14 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
     dev: true
+
+  /tar-stream@3.1.6:
+    resolution: {integrity: sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==}
+    dependencies:
+      b4a: 1.6.4
+      fast-fifo: 1.3.2
+      streamx: 2.15.5
+    dev: false
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -6264,6 +6447,13 @@ packages:
       y18n: 5.0.8
       yargs-parser: 21.1.1
     dev: true
+
+  /yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+    dev: false
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/src/server/actions/Agencies.ts
+++ b/src/server/actions/Agencies.ts
@@ -209,12 +209,7 @@ export async function updateService(
       data: { message: 'Service not found' },
     });
   }
-  const service = await ServiceModel.findById(id)
-    .populate({
-      path: 'info',
-      populate: { path: 'services' },
-    })
-    .exec();
+  const service = await ServiceModel.findById(id).exec();
   return service as Service;
 }
 

--- a/src/server/models/AgencyInfoForm.ts
+++ b/src/server/models/AgencyInfoForm.ts
@@ -149,14 +149,12 @@ const AgencyInfoFormSchema = new mongoose.Schema<AgencyInfoForm>(
       type: ContactInfoSchema,
       required: true,
     },
-    services: {
-      type: [
-        {
-          type: mongoose.Schema.Types.ObjectId,
-          ref: 'Service',
-        },
-      ],
-    },
+    services: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Service',
+      },
+    ],
     volunteerOpportunities: {
       type: Boolean,
     },

--- a/src/utils/types/models.ts
+++ b/src/utils/types/models.ts
@@ -133,10 +133,11 @@ export interface Service {
 }
 
 export interface Agency {
+  _id?: string;
   createdAt?: Date;
   updatedAt?: Date;
   name: string;
-  info: AgencyInfoForm;
+  info: AgencyInfoForm[];
   updateScheduleInDays: number;
   emailSentTimestamp?: Date;
   currentStatus?: 'Completed' | 'Needs Review' | 'Expired';

--- a/test/mongo.test.ts
+++ b/test/mongo.test.ts
@@ -1,0 +1,195 @@
+import { Agency, AgencyInfoForm, Service } from '@/utils/types';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { testAgency } from './testData/testAgency';
+import mongoose from 'mongoose';
+
+let mongoServer: MongoMemoryServer;
+let getAgencies: () => Promise<Agency[]>;
+let createService: (service: Service) => Promise<Service>;
+let createAgency: (agency: Agency) => Promise<Agency>;
+let updateAgency: (
+  id: string,
+  updates: Partial<Agency>
+) => Promise<Agency | null>;
+let updateService: (
+  id: string,
+  updates: Partial<Service>
+) => Promise<Service | null>;
+let getAgencyById: (id: string) => Promise<Agency | null>;
+let createAgencyInfo: (info: AgencyInfoForm) => Promise<AgencyInfoForm>;
+let getPaginatedAgencies: (page: number, pageSize: number) => Promise<Agency[]>;
+let deleteService: (id: string) => Promise<Service | null>;
+let deleteAgency: (id: string) => Promise<Agency | null>;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const mongoUri = mongoServer.getUri();
+  process.env.MONGODB_URI = mongoUri;
+
+  const dbConnect = (await import('@/utils/db-connect')).default;
+  await dbConnect();
+  const agenciesModule = await import('@/server/actions/Agencies');
+  getAgencies = agenciesModule.getAgencies;
+  createService = agenciesModule.createService;
+  createAgency = agenciesModule.createAgency;
+  updateAgency = agenciesModule.updateAgency;
+  updateService = agenciesModule.updateService;
+  getAgencyById = agenciesModule.getAgencyById;
+  createAgencyInfo = agenciesModule.createAgencyInfo;
+  getPaginatedAgencies = agenciesModule.getPaginatedAgencies;
+  deleteService = agenciesModule.deleteService;
+  deleteAgency = agenciesModule.deleteAgency;
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+describe('Agency', () => {
+  it('should initially return an empty array', async () => {
+    const agencies = await getAgencies();
+    expect(agencies).toEqual([]);
+  });
+
+  it('should add an agency/service to the db, and confirm it is there', async () => {
+    const agencyCopy = { ...testAgency };
+    const { info, ...agencyWithoutInfo } = agencyCopy;
+    const { services, ...infoWithoutServices } = info[0];
+
+    const serviceIds = [];
+    for (const service of services!) {
+      const newService = await createService(service);
+      serviceIds.push(newService._id);
+    }
+    const updatedInfo = {
+      ...infoWithoutServices,
+      services: serviceIds,
+    };
+
+    const agencyInfo = await createAgencyInfo(
+      updatedInfo as unknown as AgencyInfoForm
+    );
+
+    const agency = { ...agencyWithoutInfo, info: agencyInfo._id };
+
+    const createdAgency = await createAgency(agency as unknown as Agency);
+    const getAgency = await getAgencyById(createdAgency._id as string);
+
+    expect(getAgency!.name).toEqual(agencyCopy.name);
+  });
+
+  it('should update the legalAgencyName field of an agency', async () => {
+    // Grab previously created agency
+    const agencies = await getAgencies();
+    const agency = agencies[0];
+
+    // Update the legalAgencyName field
+    const updatedAgencyName = 'Updated Legal Agency Name';
+    await updateAgency(agency._id as string, {
+      name: updatedAgencyName,
+    });
+
+    // Fetch the updated agency
+    const updatedAgency = await getAgencyById(agency._id as string);
+
+    // Check if the legalAgencyName field has been updated
+    expect(updatedAgency?.name).toBe(updatedAgencyName);
+  });
+
+  it('should update the fullDescription of a service', async () => {
+    // Grab previously created agency
+    const agencies = await getAgencies();
+    const agency = agencies[0];
+
+    // Update the fullDescription field
+    const updatedFullDescription = 'Updated Full Description';
+    await updateService(agency.info[0].services![0]._id as string, {
+      fullDescription: updatedFullDescription,
+    });
+
+    // Fetch the updated Agency
+    const updatedAgency = await getAgencyById(agency._id as string);
+
+    // Check if the legalAgencyName field has been updated
+    expect(updatedAgency!.info[0].services![0].fullDescription).toBe(
+      updatedFullDescription
+    );
+  });
+
+  it('Create a new agency, then check to ensure virtual fields are set to currentStatus: complete and daysSinceEmailSent: 0', async () => {
+    // Grab prevously created agency
+    const agencies = await getAgencies();
+    const agency = agencies[0];
+
+    // Check if the currentStatus field is set to complete
+    expect(agency.currentStatus).toBe('Completed');
+
+    // Check if the daysSinceEmailSent field is set to 0
+    expect(agency.daysSinceEmailSent).toBe(0);
+  });
+
+  it('Test page return size from getPagineatedAgencies', async () => {
+    let agencies = await getPaginatedAgencies(1, 1);
+    expect(agencies.length).toBe(1);
+    agencies = await getPaginatedAgencies(1, 2);
+    expect(agencies.length).toBe(1);
+    agencies = await getPaginatedAgencies(2, 10);
+    expect(agencies.length).toBe(0);
+
+    // Insert 20 agencies
+    for (let i = 0; i < 20; i++) {
+      const agencyCopy = { ...testAgency };
+      const { info, ...agencyWithoutInfo } = agencyCopy;
+      const { services, ...infoWithoutServices } = info[0];
+
+      const serviceIds = [];
+      for (const service of services!) {
+        const newService = await createService(service);
+        serviceIds.push(newService._id);
+      }
+      const updatedInfo = {
+        ...infoWithoutServices,
+        services: serviceIds,
+      };
+
+      const agencyInfo = await createAgencyInfo(
+        updatedInfo as unknown as AgencyInfoForm
+      );
+
+      const agency = { ...agencyWithoutInfo, info: agencyInfo._id };
+
+      await createAgency(agency as unknown as Agency);
+    }
+
+    agencies = await getPaginatedAgencies(1, 10);
+    expect(agencies.length).toBe(10);
+  });
+
+  it('should delete a service from an agency', async () => {
+    // Grab previously created agency
+    const agencies = await getAgencies();
+    const agency = agencies[0];
+
+    // Delete the service
+    await deleteService(agency.info[0].services![0]._id!);
+
+    // Grab service again
+    const servicelessAgency = await getAgencyById(agency._id as string);
+    expect(servicelessAgency!.info[0].services!.length).toBe(0);
+  });
+
+  it('should delete a agency from the db', async () => {
+    // Grab previously created agencys
+    const agencies = await getAgencies();
+    const agency = agencies[0];
+    const originalSize = agencies.length;
+
+    // Delete the service
+    await deleteAgency(agency._id!);
+
+    // Grab agencies again
+    const shorterAgencies = await getAgencies();
+    expect(shorterAgencies.length).toBe(originalSize - 1);
+  });
+});

--- a/test/testData/testAgency.ts
+++ b/test/testData/testAgency.ts
@@ -1,0 +1,106 @@
+import { Agency } from '@/utils/types';
+export const testAgency: Agency = {
+  name: 'This is another agency',
+  info: [
+    {
+      legalAgencyName: 'This is another agency',
+      alsoKnownAs: [],
+      legalOrganizationalStatus: ['Non-profit'],
+      briefAgencyDescription:
+        'Non-profit organization providing community services.',
+      directorNameOrTitle: 'bob',
+      serviceArea: {
+        locations: [
+          {
+            confidential: false,
+            physicalAddress: '123 Main St',
+            county: 'Knox',
+            city: 'Knoxville',
+            state: 'Tennessee',
+            zipCode: '37996',
+          },
+        ],
+        statewide: true,
+        nationwide: false,
+      },
+      fundingSources: ['Federal', 'Donations'],
+      location: {
+        confidential: false,
+        physicalAddress: '123 Main St',
+        county: 'Knox',
+        city: 'Knoxville',
+        state: 'Tennessee',
+        zipCode: '37996',
+      },
+      languageTeleInterpreterService: true,
+      languages: ['Spanish', 'ASL'],
+      languagesWithoutPriorNotice: ['French', 'Russian'],
+      accessibilityADA: true,
+      regularHoursOpening: '9:00 AM',
+      regularHoursClosing: '5:00 PM',
+      regularDaysOpen: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+      updaterContactInfo: {
+        name: 'Billy',
+        title: 'Guy',
+        phoneNumber: '555-555-5555',
+        faxNumber: '555-555-5556',
+        email: 'info@coolservice.org',
+        hideFromWebsite: false,
+        additionalNumbers: [],
+      },
+      services: [
+        {
+          fullDescription: 'hi this a description.',
+          contactPersonName: 'Emma',
+          daysOpen: [
+            {
+              day: 'Monday',
+              openTime: '9:00 AM',
+              closeTime: '5:00 PM',
+            },
+            {
+              day: 'Wednesday',
+              openTime: '10:00 AM',
+              closeTime: '6:00 PM',
+            },
+            {
+              day: 'Friday',
+              openTime: '8:30 AM',
+              closeTime: '4:30 PM',
+            },
+          ],
+          eligibilityRequirements: 'Must have an annual income below $20,000.',
+          applicationProcess: ['Walk-in'],
+          applicationProcessReferralRequiredByWhom: 'No referral required',
+          feeCategory: 'No Fee',
+          requiredDocuments: ['State Issued I.D.'],
+        },
+      ],
+      volunteerOpportunities: false,
+      volunteerOpportunitiesEligibility: '18 years and older',
+      volunteerCoordinatorContactInfo: {
+        name: 'Billy',
+        title: 'Guy',
+        phoneNumber: '555-555-5555',
+        faxNumber: '555-555-5556',
+        email: 'info@coolservice.org',
+        hideFromWebsite: false,
+        additionalNumbers: [],
+      },
+      donations: [
+        'Non-perishable food items, warm clothing, and hygiene products',
+      ],
+      contactInfo: {
+        phoneNumber: '555-555-5555',
+        faxNumber: '555-555-5556',
+        tollFreeNumber: '1-800-123-4567',
+        TDDTTYNumber: '555-555-5557',
+        additionalNumbers: ['555-555-5558', '555-555-5559'],
+        email: 'info@coolservice.org',
+        website: 'https://www.coolservice.org',
+      },
+    },
+  ],
+  updateScheduleInDays: 36,
+  emailSentTimestamp: new Date(),
+};


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
Adds mongodb-memory-server to facilitate testing server actions without the need to connect to the external mongodb instance.
Tests all server actions at least once.
Adds test data to the test directory.
## Relevant issue(s)
Closes #49 
<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR

# Running Tests
`pnpm test`
