### PR TITLE
Temporary fix for mongoose return types

### DIFF
--- a/src/server/actions/Agencies.ts
+++ b/src/server/actions/Agencies.ts
@@ -221,18 +221,21 @@ export async function updateService(
  */
 export async function deleteAgency(id: string): Promise<Agency | null> {
   await dbConnect();
-  const deletedAgency = await AgencyModel.findByIdAndDelete(id).catch(
+  // A mongoose update changed the return type of findByIdAndDelete
+  // https://github.com/Automattic/mongoose/issues/14233
+  // Should be fixed in the next 7.6.x release
+  const deletedAgency = (await AgencyModel.findByIdAndDelete(id).catch(
     (error) => {
       mongoErrorHandler(error);
     }
-  );
+  )) as unknown as Agency;
   if (!deletedAgency) {
     throw new JSendResponse({
       status: 'fail',
       data: { message: 'Agency not found' },
     });
   }
-  return deletedAgency as Agency;
+  return deletedAgency;
 }
 
 /**
@@ -243,18 +246,21 @@ export async function deleteAgency(id: string): Promise<Agency | null> {
  */
 export async function deleteService(id: string): Promise<Service | null> {
   await dbConnect();
-  const deletedService = await ServiceModel.findByIdAndDelete(id).catch(
+  // A mongoose update changed the return type of findByIdAndDelete
+  // https://github.com/Automattic/mongoose/issues/14233
+  // Should be fixed in the next 7.6.x release
+  const deletedService = (await ServiceModel.findByIdAndDelete(id).catch(
     (error) => {
       mongoErrorHandler(error);
     }
-  );
+  )) as unknown as Service;
   if (!deletedService) {
     throw new JSendResponse({
       status: 'fail',
       data: { message: 'Service not found' },
     });
   }
-  return deletedService as Service;
+  return deletedService;
 }
 
 /**


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
The mongoose typescript definitions changed the return type for the function `findByIdAndDelete` causing a type warning in our server action. https://github.com/Automattic/mongoose/issues/14233

This should be fixed in the next minor version of 7.6.9 for mongoose.
## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
